### PR TITLE
fix(ngx-jodit): Fixed value handling for reactive forms

### DIFF
--- a/apps/demo/src/app/app.component.html
+++ b/apps/demo/src/app/app.component.html
@@ -25,7 +25,23 @@
     README</a>.
   </p>
 
-  <ngx-jodit [(ngModel)]="value" [options]="options" #ngxJodit></ngx-jodit>
+  <div class="container">
+    <div class="row">
+      <div class="col">
+        <h4>Template driven form</h4>
+        <ngx-jodit [(ngModel)]="value" [options]="options" #ngxJodit></ngx-jodit>
+        <div class="py-3">Value: {{ value | json }}</div>
+      </div>
+      <div class="col">
+        <h4>Reactive form</h4>
+        <form [formGroup]="formGroup" class="my-0">
+          <ngx-jodit [options]="options" formControlName="editor"></ngx-jodit>
+        </form>
+        <div class="py-3">Value: {{ this.formGroup.get("editor")?.value | json }}</div>
+      </div>
+    </div>
+  </div>
+
   <h3 class="pt-3">Options</h3>
   <p>
     All

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -1,14 +1,20 @@
-import {Component, ViewChild} from '@angular/core';
-import {JoditConfig, NgxJoditComponent} from 'ngx-jodit';
-import 'jodit/esm/plugins/bold/bold.js';
 import 'jodit/esm/plugins/add-new-line/add-new-line.js';
+import 'jodit/esm/plugins/bold/bold.js';
 import 'jodit/esm/plugins/fullsize/fullsize.js';
-import 'jodit/esm/plugins/source/source.js';
 import 'jodit/esm/plugins/indent/indent.js';
+import 'jodit/esm/plugins/source/source.js';
+
+import { Component, ViewChild } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { Jodit } from 'jodit';
 import de from 'jodit/esm/langs/de.js';
-import {Jodit} from 'jodit';
+import { JoditConfig, NgxJoditComponent } from 'ngx-jodit';
 
 Jodit.lang.de = de;
+
+interface FormWithJoditEditor {
+  editor: string;
+}
 
 @Component({
   selector: 'jodit-root',
@@ -17,6 +23,9 @@ Jodit.lang.de = de;
 })
 export class AppComponent {
   value = 'Some text';
+  formGroup = this.formBuilder.group<FormWithJoditEditor>({
+    editor: 'Some text in a reactive form'
+  });
   _optionsStr = '';
 
   @ViewChild('ngxJodit') ngxJodit?: NgxJoditComponent;
@@ -36,6 +45,6 @@ export class AppComponent {
 
   options: JoditConfig = {};
 
-  constructor() {
+  constructor(private formBuilder: FormBuilder) {
   }
 }

--- a/apps/demo/src/app/app.module.ts
+++ b/apps/demo/src/app/app.module.ts
@@ -3,11 +3,11 @@ import {BrowserModule} from '@angular/platform-browser';
 
 import {AppComponent} from './app.component';
 import {NgxJoditComponent} from 'ngx-jodit';
-import {FormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, NgxJoditComponent, FormsModule],
+  imports: [BrowserModule, NgxJoditComponent, FormsModule, ReactiveFormsModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/libs/ngx-jodit/README.md
+++ b/libs/ngx-jodit/README.md
@@ -85,9 +85,16 @@ All [options](https://xdsoft.net/jodit/docs/classes/config.Config.html) from Jod
        ```
 
   - With AngularForms (make sure to import AngularForms):
+    - Template driven
 
       ```angular2html
         <ngx-jodit [(ngModel)]="value" [options]="options"></ngx-jodit>
+      ```
+    - Reactive
+      ```angular2html
+        <form [formGroup]="formGroup">
+          <ngx-jodit [options]="options" formControlName="editor"></ngx-jodit>
+        </form>
       ```
 
 ## How to import plugins


### PR DESCRIPTION
- Dropped `ngOnChanges` in favour of `@Input()`-setter and subject/observable pipelines
- The latter allows to "react" on the jodit editor to be initialized to then apply the (last) value written by the reactive form directive
- ... but also need preventing `ExpressionChangedAfterItHasBeenCheckedError` by delaying the value setting (to the next change detection cycle)
- Fixes #25 