### PR TITLE
fix: reactive form gets dirty after (value) initialization

### DIFF
--- a/libs/ngx-jodit/package.json
+++ b/libs/ngx-jodit/package.json
@@ -5,6 +5,7 @@
   "peerDependencies": {
     "@angular/common": ">=16.0.0",
     "@angular/core": ">=16.0.0",
+    "@angular/forms": ">=16.0.0",
     "jodit": "^4.0.0"
   },
   "author": {

--- a/libs/ngx-jodit/src/lib/ngx-jodit.component.ts
+++ b/libs/ngx-jodit/src/lib/ngx-jodit.component.ts
@@ -6,15 +6,15 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  forwardRef,
   Input,
   OnDestroy,
   Output,
   ViewChild,
+  forwardRef,
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Jodit } from 'jodit';
-import { BehaviorSubject, combineLatest, delay, distinctUntilChanged, filter, merge, Subscription, withLatestFrom } from 'rxjs';
+import { BehaviorSubject, Subscription, combineLatest, delay, distinctUntilChanged, filter, withLatestFrom } from 'rxjs';
 
 import { JoditConfig } from './types';
 
@@ -98,7 +98,6 @@ export class NgxJoditComponent implements ControlValueAccessor, AfterViewInit, O
     ).subscribe(([[_, initialized], text]) => {
       if (this.jodit && initialized) {
         this.jodit.value = text;
-        this.onChange(text);
       }
     });
   }


### PR DESCRIPTION
- `onChange` must not be called on `writeValue` but on `set value()`
- Added missing peer dependency `@angular/forms`