### PR TITLE
fix(ngx-jodit-pro): value not changing on reactive form

### DIFF
--- a/libs/ngx-jodit-pro/src/lib/ngx-jodit-pro.component.ts
+++ b/libs/ngx-jodit-pro/src/lib/ngx-jodit-pro.component.ts
@@ -105,8 +105,9 @@ export class NgxJoditProComponent implements ControlValueAccessor, AfterViewInit
       // Prevent ExpressionChangedAfterItHasBeenCheckedError
       delay(0)
     ).subscribe(([[_, initialized], text]) => {
-      if (this.joditContainer?.nativeElement && initialized) {
+      if (this.jodit && initialized) {
         this.joditContainer.nativeElement.innerHTML = text;
+        this.jodit.setEditorValue(text);
       }
     });
   }

--- a/libs/ngx-jodit-pro/src/lib/ngx-jodit-pro.component.ts
+++ b/libs/ngx-jodit-pro/src/lib/ngx-jodit-pro.component.ts
@@ -47,7 +47,7 @@ export class NgxJoditProComponent implements ControlValueAccessor, AfterViewInit
     this._options = value;
 
     if (value) {
-      this.initJoditContainer();
+      this.initJoditContainer().then();
     }
   }
 
@@ -106,7 +106,6 @@ export class NgxJoditProComponent implements ControlValueAccessor, AfterViewInit
       delay(0)
     ).subscribe(([[_, initialized], text]) => {
       if (this.jodit && initialized) {
-        this.joditContainer.nativeElement.innerHTML = text;
         this.jodit.setEditorValue(text);
       }
     });
@@ -123,8 +122,8 @@ export class NgxJoditProComponent implements ControlValueAccessor, AfterViewInit
     );
   }
 
-  ngAfterViewInit() {
-    this.initJoditContainer();
+  async ngAfterViewInit() {
+    await this.initJoditContainer();
   }
 
   ngOnDestroy() {
@@ -132,14 +131,15 @@ export class NgxJoditProComponent implements ControlValueAccessor, AfterViewInit
     this.jodit?.events.destruct();
   }
 
-  initJoditContainer() {
+  async initJoditContainer() {
     if (this.joditContainer?.nativeElement) {
       if (this.jodit) {
         this.jodit.destruct();
         this.joditInitializedSubject.next(false);
       }
       this.jodit = Jodit.make(this.joditContainer.nativeElement, this._options) as IJodit;
-      this.joditContainer.nativeElement.innerHTML = this.valueSubject.getValue();
+      await this.jodit.waitForReady();
+      this.jodit.setEditorValue(this.valueSubject.getValue());
 
       this.jodit.events.on('change', (text: string) => {
         this.internValueChange = true;


### PR DESCRIPTION
Changing value via formPatch would not be displayed in editor.

This fix mimics one made almost a year ago to the regular (non-pro) version of this package as I found out during fixing.